### PR TITLE
Added shorthand command 'hs'

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "node": ">=0.8.0"
   },
   "bin": {
-    "headstart": "./bin/headstart.js"
+    "headstart": "./bin/headstart.js",
+    "hs": "./bin/headstart.js"
   }
 }


### PR DESCRIPTION
For making everybody’s life easier I’ve added a shorter command to run
headstart: `hs`

Example for new command: `hs init` or `hs build --serve`
